### PR TITLE
Support silencing sourcemap warning

### DIFF
--- a/src/rollup-plugin-prettier.js
+++ b/src/rollup-plugin-prettier.js
@@ -119,8 +119,10 @@ export class RollupPluginPrettier {
       return {code: output};
     }
 
-    console.warn(`[${this.name}] Sourcemap is enabled, computing diff is required`);
-    console.warn(`[${this.name}] This may take a moment (depends on the size of your bundle)`);
+    if (defaultSourcemap !== 'silent') {
+      console.warn(`[${this.name}] Sourcemap is enabled, computing diff is required`);
+      console.warn(`[${this.name}] This may take a moment (depends on the size of your bundle)`);
+    }
 
     const magicString = new MagicString(source);
     const changes = diff.diffChars(source, output);


### PR DESCRIPTION
Example:
```js
    plugins: [
        process.env.NODE_ENV == "production"
            ? terser()
            : prettier({
                  sourcemap: 'silent',
                  tabWidth: 4,
                  parser: 'babel'
              }),
        babel({ babelHelpers: "bundled" }),
    ],
```