### PR TITLE
feat: Add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @file Type definition for rollup-plugin-prettier
+ */
+
+import type { Options as PrettierOptions } from "prettier";
+import type { Plugin } from "rollup";
+
+declare namespace prettier {
+  interface Options extends PrettierOptions {
+    /**
+     * Directory to look for a Prettier config file.
+     *
+     * If omitted, defaults to `process.cwd()`.
+     */
+    cwd?: string;
+    /**
+     * Whether to generate a sourcemap.
+     *
+     * Note: This may take some time because rollup-plugin-prettier diffs the
+     * output to manually generate a sourcemap.
+     */
+    sourcemap?: boolean;
+  }
+}
+
+declare function prettier(options?: prettier.Options): Plugin;
+
+export = prettier;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "git@github.com:mjeanroy/rollup-plugin-prettier.git"
   },
+  "types": "./index.d.ts",
   "scripts": {
     "clean": "gulp clean",
     "lint": "gulp lint",
@@ -31,6 +32,7 @@
     "rollup": "^1.0.0 || ^2.0.0"
   },
   "dependencies": {
+    "@types/prettier": "^1.0.0 || ^2.0.0",
     "diff": "5.0.0",
     "lodash.hasin": "4.5.2",
     "lodash.isempty": "4.4.0",


### PR DESCRIPTION
This PR adds TypeScript type definitions for rollup-plugin-prettier. This enables downstream projects that want to type-check their Rollup config files to use rollup-plugin-prettier.

Hello! Thanks for creating rollup-plugin-prettier. [Many people including myself want to use TypeScript to type-check their Rollup config files.](https://github.com/rollup/rollup/issues/2879) Providing a type definition not only ensures type safety, but enables code editors (e.g. VS Code) to provide better code suggestions and hints when editing the config file, which significantly improves developer productivity. Thus, I'd like to request adding a type definition file (`index.d.ts`) for rollup-plugin-prettier.

This PR also adds [@types/prettier](https://www.npmjs.com/package/@types/prettier) as dependency. This is needed because rollup-plugin-prettier accepts the same config options used by Prettier.