### PR TITLE
refactor: resolve prettier configuration asynchronously

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export default function rollupPluginPrettier(options) {
      * @param {string} source Souce code of the final bundle.
      * @param {Object} chunkInfo Chunk info.
      * @param {Object} outputOptions Output option.
-     * @return {Object} The result containing a `code` property and, if a enabled, a `map` property.
+     * @return {Promise<Object>} The result containing a `code` property and, if a enabled, a `map` property.
      */
     renderChunk(source, chunkInfo, outputOptions) {
       return plugin.reformat(source, outputOptions.sourcemap);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -47,14 +47,14 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(result.map).not.toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(result.map).not.toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap in output options', () => {
@@ -65,14 +65,14 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: true};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    verifyWarnLogsBecauseOfSourcemap();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      verifyWarnLogsBecauseOfSourcemap();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap in output options skipping warn message', () => {
@@ -84,14 +84,14 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: true};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    verifyWarnLogsNotTriggered();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      verifyWarnLogsNotTriggered();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap (lowercase) in plugin options', () => {
@@ -103,14 +103,14 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    verifyWarnLogsBecauseOfSourcemap();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      verifyWarnLogsBecauseOfSourcemap();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap disabled in output options', () => {
@@ -121,14 +121,14 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: false};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    verifyWarnLogsNotTriggered();
-    expect(result.map).not.toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      verifyWarnLogsNotTriggered();
+      expect(result.map).not.toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with options', () => {
@@ -141,12 +141,12 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo=0;var test="hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: false};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    expect(result.code).toBe(
-        `var foo = 0;\n` +
-        `var test = 'hello world';\n`
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      expect(result.code).toBe(
+          `var foo = 0;\n` +
+          `var test = 'hello world';\n`
+      );
+    });
   });
 
   it('should remove unnecessary spaces', () => {
@@ -157,12 +157,12 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo    =    0;\nvar test = "hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: false};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should add and remove characters', () => {
@@ -173,12 +173,12 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo    =    0;var test = "hello world";';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {sourcemap: false};
-    const result = instance.renderChunk(code, chunk, outputOptions);
-
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return instance.renderChunk(code, chunk, outputOptions).then((result) => {
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should avoid side effect and do not modify plugin options', () => {
@@ -191,12 +191,12 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo = 0;';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    instance.renderChunk(code, chunk, outputOptions);
-
-    // It should not have been touched.
-    expect(options).toEqual({
-      parser: 'babel',
-      sourcemap: false,
+    return instance.renderChunk(code, chunk, outputOptions).then(() => {
+      // It should not have been touched.
+      expect(options).toEqual({
+        parser: 'babel',
+        sourcemap: false,
+      });
     });
   });
 
@@ -212,15 +212,15 @@ describe('rollup-plugin-prettier', () => {
     const instance = rollupPluginPrettier(options);
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    instance.renderChunk(code, chunk, outputOptions);
+    return instance.renderChunk(code, chunk, outputOptions).then(() => {
+      expect(prettier.format).toHaveBeenCalledWith(code, {
+        parser: 'babel',
+      });
 
-    expect(prettier.format).toHaveBeenCalledWith(code, {
-      parser: 'babel',
-    });
-
-    expect(options).toEqual({
-      parser: 'babel',
-      sourcemap: false,
+      expect(options).toEqual({
+        parser: 'babel',
+        sourcemap: false,
+      });
     });
   });
 
@@ -237,17 +237,17 @@ describe('rollup-plugin-prettier', () => {
     const instance = rollupPluginPrettier(options);
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    instance.renderChunk(code, chunk, outputOptions);
+    return instance.renderChunk(code, chunk, outputOptions).then(() => {
+      expect(prettier.format).toHaveBeenCalledWith(code, {
+        parser: 'babel',
+        singleQuote: true,
+      });
 
-    expect(prettier.format).toHaveBeenCalledWith(code, {
-      parser: 'babel',
-      singleQuote: true,
-    });
-
-    expect(options).toEqual({
-      parser: 'babel',
-      sourcemap: false,
-      singleQuote: true,
+      expect(options).toEqual({
+        parser: 'babel',
+        sourcemap: false,
+        singleQuote: true,
+      });
     });
   });
 
@@ -265,17 +265,17 @@ describe('rollup-plugin-prettier', () => {
     const code = 'var foo = 0;';
     const chunk = {isEntry: false, imports: []};
     const outputOptions = {};
-    instance.renderChunk(code, chunk, outputOptions);
+    return instance.renderChunk(code, chunk, outputOptions).then(() => {
+      expect(options).toEqual({
+        parser,
+        cwd,
+      });
 
-    expect(options).toEqual({
-      parser,
-      cwd,
-    });
-
-    expect(prettier.format).toHaveBeenCalledWith(code, {
-      parser,
-      singleQuote: true,
-      tabWidth: 2,
+      expect(prettier.format).toHaveBeenCalledWith(code, {
+        parser,
+        singleQuote: true,
+        tabWidth: 2,
+      });
     });
   });
 });

--- a/test/rollup-plugin-prettier.spec.js
+++ b/test/rollup-plugin-prettier.spec.js
@@ -43,20 +43,20 @@ describe('RollupPluginPrettier', () => {
     expect(plugin.getSourcemap()).toBeNull();
   });
 
-  it('should run esformatter without sourcemap by default', () => {
+  it('should run plugin without sourcemap by default', () => {
     const plugin = new RollupPluginPrettier({
       parser: 'babel',
     });
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code);
-
-    verifyWarnLogsNotTriggered();
-    expect(result.map).not.toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+    return plugin.reformat(code).then((result) => {
+      verifyWarnLogsNotTriggered();
+      expect(result.map).not.toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap', () => {
@@ -66,16 +66,16 @@ describe('RollupPluginPrettier', () => {
     });
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code);
+    return plugin.reformat(code).then((result) => {
+      expect(plugin.getSourcemap()).toBe(true);
 
-    expect(plugin.getSourcemap()).toBe(true);
-
-    verifyWarnLogsBecauseOfSourcemap();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+      verifyWarnLogsBecauseOfSourcemap();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap skipping warn message', () => {
@@ -85,16 +85,16 @@ describe('RollupPluginPrettier', () => {
     });
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code);
+    return plugin.reformat(code).then((result) => {
+      expect(plugin.getSourcemap()).toBe('silent');
 
-    expect(plugin.getSourcemap()).toBe('silent');
-
-    verifyWarnLogsNotTriggered();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+      verifyWarnLogsNotTriggered();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap if it has been enabled', () => {
@@ -108,16 +108,16 @@ describe('RollupPluginPrettier', () => {
     plugin.enableSourcemap();
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code);
+    return plugin.reformat(code).then((result) => {
+      expect(plugin.getSourcemap()).toBe(true);
 
-    expect(plugin.getSourcemap()).toBe(true);
-
-    verifyWarnLogsBecauseOfSourcemap();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+      verifyWarnLogsBecauseOfSourcemap();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier with sourcemap enable in reformat', () => {
@@ -127,16 +127,16 @@ describe('RollupPluginPrettier', () => {
     });
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code, true);
+    return plugin.reformat(code, true).then((result) => {
+      expect(plugin.getSourcemap()).toBe(false);
 
-    expect(plugin.getSourcemap()).toBe(false);
-
-    verifyWarnLogsBecauseOfSourcemap();
-    expect(result.map).toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+      verifyWarnLogsBecauseOfSourcemap();
+      expect(result.map).toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier without sourcemap enable in reformat', () => {
@@ -146,16 +146,16 @@ describe('RollupPluginPrettier', () => {
     });
 
     const code = 'var foo=0;var test="hello world";';
-    const result = plugin.reformat(code, false);
+    return plugin.reformat(code, false).then((result) => {
+      expect(plugin.getSourcemap()).toBe(true);
 
-    expect(plugin.getSourcemap()).toBe(true);
-
-    verifyWarnLogsNotTriggered();
-    expect(result.map).not.toBeDefined();
-    expect(result.code).toBe(
-        'var foo = 0;\n' +
-        'var test = "hello world";\n'
-    );
+      verifyWarnLogsNotTriggered();
+      expect(result.map).not.toBeDefined();
+      expect(result.code).toBe(
+          'var foo = 0;\n' +
+          'var test = "hello world";\n'
+      );
+    });
   });
 
   it('should run prettier using config file from given current working directory', () => {
@@ -171,19 +171,19 @@ describe('RollupPluginPrettier', () => {
     spyOn(prettier, 'format').and.callThrough();
 
     const code = 'var foo = 0;';
-    const result = plugin.reformat(code);
+    return plugin.reformat(code).then((result) => {
+      expect(result.code).toBe('var foo = 0;\n');
 
-    expect(result.code).toBe('var foo = 0;\n');
+      expect(options).toEqual({
+        parser,
+        cwd,
+      });
 
-    expect(options).toEqual({
-      parser,
-      cwd,
-    });
-
-    expect(prettier.format).toHaveBeenCalledWith(code, {
-      parser,
-      singleQuote: true,
-      tabWidth: 2,
+      expect(prettier.format).toHaveBeenCalledWith(code, {
+        parser,
+        singleQuote: true,
+        tabWidth: 2,
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Resolve prettier configuration asynchronously, mandatory for prettier >= 3 compatibility since `resolveConfigSync` has been removed.