### PR TITLE
chore: add public package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:mjeanroy/rollup-plugin-prettier.git"
+    "url": "git+https://github.com/mjeanroy/rollup-plugin-prettier.git"
+  },
+  "homepage": "https://github.com/mjeanroy/rollup-plugin-prettier#readme",
+  "bugs": {
+    "url": "https://github.com/mjeanroy/rollup-plugin-prettier/issues"
   },
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
- switch package repository metadata from SSH form to public git+https
- add homepage and bugs URLs for npm consumers

## Validation
- node metadata assertion passed
- npm pack --dry-run --ignore-scripts --json .
- git diff --check